### PR TITLE
Fix contributor spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Thanks to its multi-user support, multiple people can work on their own part of 
 
 BIMserver is built for developers. We've got a great wiki on https://github.com/opensourceBIM/BIMserver/wiki and are very active supporting developers on https://github.com/opensourceBIM/BIMserver/issues 
 
-(C) Copyright by the contributers / BIMserver.org
+(C) Copyright by the contributors / BIMserver.org
 
 Licence: GNU Affero General Public License, version 3 (see http://www.gnu.org/licenses/agpl-3.0.html)
 Beware: this project makes intensive use of several other projects with different licenses. Some plugins and libraries are published under a different license.


### PR DESCRIPTION
## Summary
- fix the typo "contributers" in README

## Testing
- `grep -n "contribut" README.md`


------
https://chatgpt.com/codex/tasks/task_e_68693780e46c832ca74605f6ff3da702